### PR TITLE
fix stdout & stderr redirection

### DIFF
--- a/grabagentmem.sh
+++ b/grabagentmem.sh
@@ -12,7 +12,7 @@ for pid in $sshagentpids; do
     startstack=$(echo $stackmem | awk '{print $1}')
     stopstack=$(echo $stackmem | awk '{print $2}')
     
-    gdb --batch -pid $pid -ex "dump memory $outputdir/sshagent-$pid.stack 0x$startstack 0x$stopstack" 2&>1 >/dev/null 
+    gdb --batch -pid $pid -ex "dump memory $outputdir/sshagent-$pid.stack 0x$startstack 0x$stopstack" &>/dev/null
 
     # GDB doesn't error out properly if this fails.  
     # This will provide feedback if the file is actually created


### PR DESCRIPTION
The redirection in gdb command is most likely mistyped. The was it is written it passes an argument `2` to the `gdb` and it actually produces a file `1`.
```bash
gdb ... 2&>1 >/dev/null
```

The author most likely wanted to write the code below which redirects the stderr to stdout and then both to `/dev/null`:
```
gdb ... 2>&1 >/dev/null
```

This PR fixes that.
